### PR TITLE
Update version to v0.34.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build msyh
 on: [push]
 
 env:
-  version: 0.34.3
+  version: 0.34.5
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates `env.version` to `0.34.5` due to a [newer version](https://github.com/be5invis/Sarasa-Gothic/releases/tag/v0.34.5) of Sarasa Gothic is released.
